### PR TITLE
Use Linux's env command instead of assuming PHP path.

### DIFF
--- a/bin/commit
+++ b/bin/commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 use Smacme\Commit\EmojiList;


### PR DESCRIPTION
Usage with phpenv and any other PHP interpretor not in the assumed path causes issues.

Fixes #8